### PR TITLE
added webDriverFactory, firefox browser, added to able to set options…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <browser>chrome</browser>
+        <options>start-maximized</options>
     </properties>
 
     <dependencies>
@@ -55,6 +59,21 @@
 
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <browser>${browser}</browser>
+                        <options>${options}</options>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
             <PatternLayout pattern="%highlight{[%d{HH:mm:ss.SSS}] | %-5p | %-32.42t | %-32.42c{1} | %m%n}{FATAL=red blink, ERROR=red blink, WARN=yellow bold, INFO=black, DEBUG=green bold, TRACE=blue}"/>
         </Console>
         <File name="MyFile" fileName="logs.log">
-            <PatternLayout>
+            <PatternLayout charset="UTF-8">
                 <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
             </PatternLayout>
         </File>

--- a/src/test/java/OpenMainPageTest.java
+++ b/src/test/java/OpenMainPageTest.java
@@ -1,14 +1,11 @@
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class OpenMainPageTest {
 
@@ -17,8 +14,10 @@ public class OpenMainPageTest {
 
     @Before
     public void setUp() {
-        WebDriverManager.chromedriver().setup();
-        driver = new ChromeDriver();
+        //ввод опций через пробел внутри кавычек(если опций несколько), например: mvn clean test -Dbrowser="chrome" -Doptions="window-size=1920,1080 incognito" (для линукса кавычки одинарные)
+        driver = WebDriverFactory.create(System.getProperty("browser"), System.getProperty("options"));
+
+        //driver = WebDriverFactory.create("chrome");  //для запуска из ИДЕ (ручная отладка) или строкой выше, но тогда параметры будут браться из пом-файла
         logger.info("Драйвер поднят");
     }
 

--- a/src/test/java/WebDriverFactory.java
+++ b/src/test/java/WebDriverFactory.java
@@ -1,0 +1,50 @@
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+public class WebDriverFactory {
+
+    private static Logger logger = LogManager.getLogger(WebDriverFactory.class);
+    public enum WebDriverName {
+        CHROME,
+        FIREFOX
+    }
+
+    public static WebDriver create(String webDriverName, String options) {
+        WebDriverName driverName = WebDriverName.valueOf(webDriverName.toUpperCase());
+        WebDriver driver = null;
+        String[] browserOptions = new String[0];
+        if (options != null)  browserOptions = options.split(" ");
+
+        switch (driverName) {
+            case CHROME:
+                WebDriverManager.chromedriver().setup();
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.addArguments(browserOptions);
+                driver = new ChromeDriver(chromeOptions);
+                logger.info("Инициализирован ChromeDriver");
+                break;
+            case FIREFOX:
+                WebDriverManager.firefoxdriver().setup();
+                FirefoxOptions firefoxOptions = new FirefoxOptions();
+                firefoxOptions.addArguments(browserOptions);
+                driver = new FirefoxDriver(firefoxOptions);
+                logger.info("Инициализирован FirefoxDriver");
+                break;
+            default:
+                logger.error("Указанный WebDriver не реализован");
+        }
+
+        return driver;
+    }
+
+    //для локального вызова (не через консоль)
+    public static WebDriver create(String webDriverName) {
+        return create(webDriverName, null);
+    }
+}


### PR DESCRIPTION
Запуск из командной строки регистронезависимый, для передачи более одной опции используется пробел: 
пример:  -Doptions="options1 options2"
реализовано два браузера: chrome и firefox

---------------------------
**Домашнее задание**
Реализовать WebDriverFactory класс
Цель: В результате выполнения дз, участники создадут для себя Factory-класс, предоставляющий удобный интерфейс для запуска драйверов разных браузеров
Создайте класс WebDriverFactory со статическим методом create();

Метод create() принимает обязательный параметр webDriverName и необязательный параметр options, а возвращает соответствующий имени вебдрайвер с заданными (если были) options

Примеры использования
WebDriver wd = WebDriverFactory.createNewDriver("chrome");
или
FirefoxOptions options = new FirefoxOptions();
WebDriver wd = WebDriverFactory.createNewDriver("firefox", options);


Про паттерн Factory: https://refactoring.guru/ru/design-patterns/factory-method
Критерии оценки: Проверять буду запуском тестов из командной строки: mvn clean test -Dbrowser='cHrOmE' (да, именно cHrOmE)
Критерий оценивания:
+1 балл - проект компилируется и собирается
+1 балл - в репозитории нет лишних файлов (.iml, директория idea и т.д.)
+1 балл - регистр значения параметра -Dbrowser не влияет на результат
+1 балл - для хранения имен драйверов используются Enum